### PR TITLE
Replace == by is to avoid FutureWarning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /dist
 /doc/build
+__pycache__

--- a/pydc1394/frame.py
+++ b/pydc1394/frame.py
@@ -86,7 +86,7 @@ class Frame(ndarray):
 
         If called with an image object, inherit the properties of that image.
         """
-        if img == None:
+        if img is None:
             return
         # do not inherit _frame and _cam since we also get called on copy()
         # and should not hold references to the frame in this case


### PR DESCRIPTION
Simple fix to remove annoying warning:
pydc1394/pydc1394/frame.py:89: FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.